### PR TITLE
Add Labels to Docker Images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,10 @@ RUN ["chmod", "-R", "u=rwX,go=rX", "/rootfs"]
 
 FROM scratch
 
+LABEL org.opencontainers.image.documentation='https://icinga.com/docs/icinga-db/latest/doc/01-About/' \
+      org.opencontainers.image.source='https://github.com/Icinga/icingadb' \
+      org.opencontainers.image.licenses='GPL-2.0+'
+
 COPY --from=base /rootfs/ /
 COPY --from=base --chown=icingadb:icingadb /empty /etc/icingadb
 COPY --from=entrypoint /entrypoint/entrypoint /entrypoint


### PR DESCRIPTION
As a user I want to know where stuff in my image came from. Those standardized tags allow automated tools to find the source code. For instance, this will allow renovate bot to show a changelog (based on the github releases) and provide a nice link to the repo.